### PR TITLE
Add error handler middleware

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
+import { errorHandler } from "./middlewares/errorHandler";
+
 const config = require("dotenv").config();
 const express = require("express");
 const app = express();
@@ -49,6 +51,8 @@ app.get("/", (req, res) => {
   res.send("Testing!");
 });
 
+// override default html error page with custom error handler
+app.use(errorHandler);
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`);
 });

--- a/middlewares/errorHandler.ts
+++ b/middlewares/errorHandler.ts
@@ -1,8 +1,10 @@
 import { NextFunction, Response, Request } from "express";
 import { wavlakeErrorHandler } from "../library/errorHandler";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime";
 
+// https://www.prisma.io/docs/reference/api-reference/error-reference
 export const errorHandler = (
-  error: any,
+  error: PrismaClientKnownRequestError | any,
   req: Request,
   res: Response,
   next: NextFunction

--- a/middlewares/errorHandler.ts
+++ b/middlewares/errorHandler.ts
@@ -1,0 +1,12 @@
+import { NextFunction, Response, Request } from "express";
+import { wavlakeErrorHandler } from "../library/errorHandler";
+
+export const errorHandler = (
+  error: any,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  wavlakeErrorHandler(error);
+  res.status(error.status || 500).json({ error });
+};


### PR DESCRIPTION
It seems the default express error handling sends an html page in the response, with the error message embedded in the html.

This PR adds an error handler function, as the lest middleware in index.ts, so that the error message is sent in the response body as `{ error: "some message" }`

<img width="420" alt="Screenshot 2023-06-27 at 11 33 42 PM" src="https://github.com/wavlake/catalog/assets/14062229/ab8b2dfc-c235-44e2-8858-7363969683ea">
