### PR TITLE
Set all responses to camelCase

### DIFF
--- a/controllers/albums.js
+++ b/controllers/albums.js
@@ -67,7 +67,7 @@ const get_albums_by_artist_id = handleErrorAsync(async (req, res, next) => {
   };
 
   const albums = await prisma.album.findMany({
-    where: { artist_id: request.artistId, deleted: false },
+    where: { artistId: request.artistId, deleted: false },
   });
 
   res.json(albums);
@@ -121,7 +121,7 @@ const create_album = handleErrorAsync(async (req, res, next) => {
                 description: request.description,
                 artwork_url: liveUrl,
               },
-              ["id", "artist_id", "title", "description", "artwork_url"]
+              ["*"]
             )
             .then((data) => {
               log.debug(
@@ -140,7 +140,13 @@ const create_album = handleErrorAsync(async (req, res, next) => {
                 : fs.unlink(`${uploadPath}`, (err) => {
                     if (err) log.debug(`Error deleting local file : ${err}`);
                   });
-              res.send(data);
+              res.send({
+                id: data[0]["id"],
+                title: data[0]["title"],
+                artworkUrl: data[0]["artwork_url"],
+                artistId: data[0]["artist_id"],
+                description: data[0]["description"],
+              });
             })
             .catch((err) => {
               if (err instanceof multer.MulterError) {
@@ -179,10 +185,16 @@ const update_album = handleErrorAsync(async (req, res, next) => {
         description: request.description,
         updated_at: db.knex.fn.now(),
       },
-      ["id", "artist_id", "title", "description", "artwork_url"]
+      ["*"]
     )
     .then((data) => {
-      res.send(data);
+      res.send({
+        id: data[0]["id"],
+        title: data[0]["title"],
+        artworkUrl: data[0]["artwork_url"],
+        artistId: data[0]["artist_id"],
+        description: data[0]["description"],
+      });
     })
     .catch((err) => {
       log.debug(`Error editing album ${request.albumId}: ${err}`);
@@ -307,7 +319,7 @@ const delete_album = handleErrorAsync(async (req, res, next) => {
                 .where("id", "=", request.albumId)
                 .update({ deleted: true }, ["id", "title"])
                 .then((data) => {
-                  res.send(data);
+                  res.send(data[0]);
                 })
                 .catch((err) => {
                   log.debug(`Error deleting album ${request.albumId}: ${err}`);

--- a/controllers/artists.js
+++ b/controllers/artists.js
@@ -29,7 +29,7 @@ const get_artist_by_url = handleErrorAsync(async (req, res, next) => {
   };
 
   const artist = await prisma.artist.findFirstOrThrow({
-    where: { artist_url: request.artistUrl },
+    where: { artistUrl: request.artistUrl },
   });
 
   res.json(artist);
@@ -53,7 +53,7 @@ const get_artists_by_account = handleErrorAsync(async (req, res, next) => {
   };
 
   const artists = await prisma.artist.findMany({
-    where: { user_id: request.userId, deleted: false },
+    where: { userId: request.userId, deleted: false },
   });
 
   res.json(artists);
@@ -123,19 +123,7 @@ const create_artist = handleErrorAsync(async (req, res, next) => {
                   artwork_url: liveUrl,
                   artist_url: format.urlFriendly(request.name),
                 },
-                [
-                  "id",
-                  "user_id",
-                  "name",
-                  "bio",
-                  "twitter",
-                  "instagram",
-                  "npub",
-                  "youtube",
-                  "website",
-                  "artwork_url",
-                  "artist_url",
-                ]
+                ["*"]
               )
               .then((data) => {
                 log.debug(
@@ -154,7 +142,19 @@ const create_artist = handleErrorAsync(async (req, res, next) => {
                   : fs.unlink(`${uploadPath}`, (err) => {
                       if (err) log.debug(`Error deleting local file : ${err}`);
                     });
-                res.send(data);
+                res.send({
+                  id: data[0]["id"],
+                  userId: data[0]["user_id"],
+                  name: data[0]["name"],
+                  bio: data[0]["bio"],
+                  twitter: data[0]["twitter"],
+                  instagram: data[0]["instagram"],
+                  npub: data[0]["npub"],
+                  youtube: data[0]["youtube"],
+                  website: data[0]["website"],
+                  artworkUrl: data[0]["artwork_url"],
+                  artistUrl: data[0]["artist_url"],
+                });
               })
               .catch((err) => {
                 if (err instanceof multer.MulterError) {
@@ -216,22 +216,22 @@ const update_artist = handleErrorAsync(async (req, res, next) => {
         website: request.website,
         artist_url: format.urlFriendly(request.name),
       },
-      [
-        "id",
-        "user_id",
-        "name",
-        "bio",
-        "twitter",
-        "instagram",
-        "npub",
-        "youtube",
-        "website",
-        "artwork_url",
-        "artist_url",
-      ]
+      ["*"]
     )
     .then((data) => {
-      res.send(data);
+      res.send({
+        id: data[0]["id"],
+        userId: data[0]["user_id"],
+        name: data[0]["name"],
+        bio: data[0]["bio"],
+        twitter: data[0]["twitter"],
+        instagram: data[0]["instagram"],
+        npub: data[0]["npub"],
+        youtube: data[0]["youtube"],
+        website: data[0]["website"],
+        artworkUrl: data[0]["artwork_url"],
+        artistUrl: data[0]["artist_url"],
+      });
     })
     .catch((err) => {
       log.debug(`Error editing artist ${request.artistId}: ${err}`);
@@ -358,7 +358,7 @@ const delete_artist = handleErrorAsync(async (req, res, next) => {
                 .where("id", "=", request.artistId)
                 .update({ deleted: true }, ["id", "name"])
                 .then((data) => {
-                  res.send(data);
+                  res.send(data[0]);
                 })
                 .catch((err) => {
                   log.debug(

--- a/controllers/tracks.ts
+++ b/controllers/tracks.ts
@@ -33,8 +33,8 @@ const get_index_top = handleErrorAsync(async (req, res, next) => {
   };
 
   const tracks = await prisma.trackInfo.findMany({
-    where: { msat_total_30_days: { gt: 0 } },
-    orderBy: { msat_total_30_days: "desc" },
+    where: { msatTotal30Days: { gt: 0 } },
+    orderBy: { msatTotal30Days: "desc" },
     take: request.limit,
   });
 
@@ -73,7 +73,7 @@ const delete_track = handleErrorAsync(async (req, res, next) => {
           .where("id", "=", request.trackId)
           .update({ deleted: true }, ["id", "title"])
           .then((data) => {
-            res.send(data);
+            res.send(data[0]);
           })
           .catch((err) => {
             log.debug(`Error deleting track ${request.trackId}: ${err}`);
@@ -172,16 +172,7 @@ const create_track = handleErrorAsync(async (req, res, next) => {
                       duration: duration,
                       size: fileStats.size,
                     },
-                    [
-                      "id",
-                      "artist_id",
-                      "album_id",
-                      "live_url",
-                      "title",
-                      "order",
-                      "duration",
-                      "size",
-                    ]
+                    ["*"]
                   )
                   .then((data) => {
                     log.debug(
@@ -242,7 +233,17 @@ const create_track = handleErrorAsync(async (req, res, next) => {
                         );
                       });
 
-                    res.send(data);
+                    res.send({
+                      id: data[0]["id"],
+                      artistId: data[0]["artist_id"],
+                      albumId: data[0]["album_id"],
+                      title: data[0]["title"],
+                      order: data[0]["order"],
+                      duration: data[0]["duration"],
+                      liveUrl: data[0]["liveUrl"],
+                      rawUrl: data[0]["raw_url"],
+                      size: data[0]["size"],
+                    });
                   });
               });
           })
@@ -283,19 +284,20 @@ const update_track = handleErrorAsync(async (req, res, next) => {
         order: request.order,
         updated_at: db.knex.fn.now(),
       },
-      [
-        "id",
-        "artist_id",
-        "album_id",
-        "live_url",
-        "title",
-        "order",
-        "duration",
-        "size",
-      ]
+      ["*"]
     )
     .then((data) => {
-      res.send(data);
+      res.send({
+        id: data[0]["id"],
+        artistId: data[0]["artist_id"],
+        albumId: data[0]["album_id"],
+        title: data[0]["title"],
+        order: data[0]["order"],
+        duration: data[0]["duration"],
+        liveUrl: data[0]["liveUrl"],
+        rawUrl: data[0]["raw_url"],
+        size: data[0]["size"],
+      });
     })
     .catch((err) => {
       log.debug(`Error editing track ${request.trackId}: ${err}`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,9 +22,9 @@ model Album {
   id          String    @id @unique(map: "album_id_unique") @db.Uuid
   artistId    String    @db.Uuid @map("artist_id")
   title       String    @db.VarChar(255)
-  artworkUrl String?   @db.VarChar(255) @map("artwork_url")
-  createdAt  DateTime? @default(now()) @db.Timestamptz(6) @map("created_at")
-  updatedAt  DateTime? @default(now()) @db.Timestamptz(6) @map("updated_at")
+  artworkUrl  String?   @db.VarChar(255) @map("artwork_url")
+  createdAt   DateTime? @default(now()) @db.Timestamptz(6) @map("created_at")
+  updatedAt   DateTime? @default(now()) @db.Timestamptz(6) @map("updated_at")
   description String?   @db.VarChar(1000)
   deleted     Boolean?  @default(false)
   artist      Artist    @relation(fields: [artistId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "album_artist_id_foreign")
@@ -59,12 +59,12 @@ model amp_type {
 
 model Artist {
   id          String    @id @unique(map: "artist_id_unique") @db.Uuid
-  userId     String    @db.VarChar(255) @map("user_id")
+  userId      String    @db.VarChar(255) @map("user_id")
   name        String    @db.VarChar(255)
-  artworkUrl String?   @db.VarChar(255) @map("artwork_url")
-  artistUrl  String    @unique(map: "artist_artist_url_unique") @db.VarChar(255) @map("artist_url")
-  createdAt  DateTime? @default(now()) @db.Timestamptz(6) @map("created_at")
-  updatedAt  DateTime? @default(now()) @db.Timestamptz(6) @map("updated_at")
+  artworkUrl  String?   @db.VarChar(255) @map("artwork_url")
+  artistUrl   String    @unique(map: "artist_artist_url_unique") @db.VarChar(255) @map("artist_url")
+  createdAt   DateTime? @default(now()) @db.Timestamptz(6) @map("created_at")
+  updatedAt   DateTime? @default(now()) @db.Timestamptz(6) @map("updated_at")
   bio         String?   @db.VarChar(200)
   twitter     String?   @db.VarChar(255)
   instagram   String?   @db.VarChar(255)
@@ -168,19 +168,19 @@ model ranking_forty {
 /// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/check-constraints for more info.
 model Track {
   id         String    @id @unique(map: "track_id_unique") @db.Uuid
-  artistId  String    @db.Uuid @map("artist_id")
-  albumId   String    @db.Uuid @map("album_id")
+  artistId   String    @db.Uuid @map("artist_id")
+  albumId    String    @db.Uuid @map("album_id")
   title      String    @db.VarChar(255)
   order      Int
-  playCount Int?      @default(0) @map("play_count")
-  msatTotal BigInt?   @default(0) @map("msat_total")
-  liveUrl   String    @db.VarChar(255) @map("live_url")
-  rawUrl    String?   @db.VarChar(128) @map("raw_url")
+  playCount  Int?      @default(0) @map("play_count")
+  msatTotal  BigInt?   @default(0) @map("msat_total")
+  liveUrl    String    @db.VarChar(255) @map("live_url")
+  rawUrl     String?   @db.VarChar(128) @map("raw_url")
   size       Int?
   duration   Int?
   deleted    Boolean?  @default(false)
-  createdAt DateTime? @default(now()) @db.Timestamptz(6) @map("created_at")
-  updatedAt DateTime? @default(now()) @db.Timestamptz(6) @map("updated_at")
+  createdAt  DateTime? @default(now()) @db.Timestamptz(6) @map("created_at")
+  updatedAt  DateTime? @default(now()) @db.Timestamptz(6) @map("updated_at")
   album      Album     @relation(fields: [albumId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "track_album_id_foreign")
   artist     Artist    @relation(fields: [artistId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "track_artist_id_foreign")
 
@@ -241,16 +241,16 @@ view TrackInfo {
   id                 String    @unique @db.Uuid
   title              String?   @db.VarChar(255)
   artist             String?   @db.VarChar(255)
-  artistUrl         String?   @db.VarChar(255) @map("artist_url")
-  avatarUrl         String?   @db.VarChar(255) @map("avatar_url")
-  artworkUrl        String?   @db.VarChar(255) @map("artwork_url")
-  msatTotal30Days BigInt? @map("msat_total_30_days")
-  msatTotal7Days  BigInt? @map("msat_total_7_days")
-  msatTotal1Days  BigInt? @map("msat_total_1_days")
-  albumTitle        String?   @db.VarChar(255) @map("album_title")
-  liveUrl           String?   @db.VarChar(255) @map("live_url")
+  artistUrl          String?   @db.VarChar(255) @map("artist_url")
+  avatarUrl          String?   @db.VarChar(255) @map("avatar_url")
+  artworkUrl         String?   @db.VarChar(255) @map("artwork_url")
+  msatTotal30Days    BigInt? @map("msat_total_30_days")
+  msatTotal7Days     BigInt? @map("msat_total_7_days")
+  msatTotal1Days     BigInt? @map("msat_total_1_days")
+  albumTitle         String?   @db.VarChar(255) @map("album_title")
+  liveUrl            String?   @db.VarChar(255) @map("live_url")
   duration           Int?
-  createdAt         DateTime? @db.Timestamptz(6) @map("created_at")
+  createdAt          DateTime? @db.Timestamptz(6) @map("created_at")
 
   @@map("track_info")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,17 +20,17 @@ model activity {
 
 model Album {
   id          String    @id @unique(map: "album_id_unique") @db.Uuid
-  artist_id   String    @db.Uuid
+  artistId    String    @db.Uuid @map("artist_id")
   title       String    @db.VarChar(255)
-  artwork_url String?   @db.VarChar(255)
-  created_at  DateTime? @default(now()) @db.Timestamptz(6)
-  updated_at  DateTime? @default(now()) @db.Timestamptz(6)
+  artworkUrl String?   @db.VarChar(255) @map("artwork_url")
+  createdAt  DateTime? @default(now()) @db.Timestamptz(6) @map("created_at")
+  updatedAt  DateTime? @default(now()) @db.Timestamptz(6) @map("updated_at")
   description String?   @db.VarChar(1000)
   deleted     Boolean?  @default(false)
-  artist      Artist    @relation(fields: [artist_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "album_artist_id_foreign")
+  artist      Artist    @relation(fields: [artistId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "album_artist_id_foreign")
   track       Track[]
 
-  @@index([artist_id], map: "idx_album_artist_id")
+  @@index([artistId], map: "idx_album_artist_id")
   @@map("album")
 }
 
@@ -59,12 +59,12 @@ model amp_type {
 
 model Artist {
   id          String    @id @unique(map: "artist_id_unique") @db.Uuid
-  user_id     String    @db.VarChar(255)
+  userId     String    @db.VarChar(255) @map("user_id")
   name        String    @db.VarChar(255)
-  artwork_url String?   @db.VarChar(255)
-  artist_url  String    @unique(map: "artist_artist_url_unique") @db.VarChar(255)
-  created_at  DateTime? @default(now()) @db.Timestamptz(6)
-  updated_at  DateTime? @default(now()) @db.Timestamptz(6)
+  artworkUrl String?   @db.VarChar(255) @map("artwork_url")
+  artistUrl  String    @unique(map: "artist_artist_url_unique") @db.VarChar(255) @map("artist_url")
+  createdAt  DateTime? @default(now()) @db.Timestamptz(6) @map("created_at")
+  updatedAt  DateTime? @default(now()) @db.Timestamptz(6) @map("updated_at")
   bio         String?   @db.VarChar(200)
   twitter     String?   @db.VarChar(255)
   instagram   String?   @db.VarChar(255)
@@ -74,11 +74,11 @@ model Artist {
   verified    Boolean?  @default(false)
   npub        String?   @db.VarChar(64)
   album       Album[]
-  user        User      @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "artist_user_id_foreign")
+  user        User      @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "artist_user_id_foreign")
   track       Track[]
 
-  @@index([artist_url], map: "idx_artist_url")
-  @@index([user_id], map: "idx_artist_user_id")
+  @@index([artistUrl], map: "idx_artist_url")
+  @@index([userId], map: "idx_artist_user_id")
   @@map("artist")
 }
 
@@ -168,24 +168,24 @@ model ranking_forty {
 /// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/check-constraints for more info.
 model Track {
   id         String    @id @unique(map: "track_id_unique") @db.Uuid
-  artist_id  String    @db.Uuid
-  album_id   String    @db.Uuid
+  artistId  String    @db.Uuid @map("artist_id")
+  albumId   String    @db.Uuid @map("album_id")
   title      String    @db.VarChar(255)
   order      Int
-  play_count Int?      @default(0)
-  msat_total BigInt?   @default(0)
-  live_url   String    @db.VarChar(255)
-  raw_url    String?   @db.VarChar(128)
+  playCount Int?      @default(0) @map("play_count")
+  msatTotal BigInt?   @default(0) @map("msat_total")
+  liveUrl   String    @db.VarChar(255) @map("live_url")
+  rawUrl    String?   @db.VarChar(128) @map("raw_url")
   size       Int?
   duration   Int?
   deleted    Boolean?  @default(false)
-  created_at DateTime? @default(now()) @db.Timestamptz(6)
-  updated_at DateTime? @default(now()) @db.Timestamptz(6)
-  album      Album     @relation(fields: [album_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "track_album_id_foreign")
-  artist     Artist    @relation(fields: [artist_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "track_artist_id_foreign")
+  createdAt DateTime? @default(now()) @db.Timestamptz(6) @map("created_at")
+  updatedAt DateTime? @default(now()) @db.Timestamptz(6) @map("updated_at")
+  album      Album     @relation(fields: [albumId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "track_album_id_foreign")
+  artist     Artist    @relation(fields: [artistId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "track_artist_id_foreign")
 
-  @@index([album_id], map: "idx_track_album_id")
-  @@index([artist_id], map: "idx_track_artist_id")
+  @@index([albumId], map: "idx_track_album_id")
+  @@index([artistId], map: "idx_track_artist_id")
   @@map("track")
 }
 
@@ -241,16 +241,16 @@ view TrackInfo {
   id                 String    @unique @db.Uuid
   title              String?   @db.VarChar(255)
   artist             String?   @db.VarChar(255)
-  artist_url         String?   @db.VarChar(255)
-  avatar_url         String?   @db.VarChar(255)
-  artwork_url        String?   @db.VarChar(255)
-  msat_total_30_days BigInt?
-  msat_total_7_days  BigInt?
-  msat_total_1_days  BigInt?
-  album_title        String?   @db.VarChar(255)
-  live_url           String?   @db.VarChar(255)
+  artistUrl         String?   @db.VarChar(255) @map("artist_url")
+  avatarUrl         String?   @db.VarChar(255) @map("avatar_url")
+  artworkUrl        String?   @db.VarChar(255) @map("artwork_url")
+  msatTotal30Days BigInt? @map("msat_total_30_days")
+  msatTotal7Days  BigInt? @map("msat_total_7_days")
+  msatTotal1Days  BigInt? @map("msat_total_1_days")
+  albumTitle        String?   @db.VarChar(255) @map("album_title")
+  liveUrl           String?   @db.VarChar(255) @map("live_url")
   duration           Int?
-  created_at         DateTime? @db.Timestamptz(6)
+  createdAt         DateTime? @db.Timestamptz(6) @map("created_at")
 
   @@map("track_info")
 }


### PR DESCRIPTION
Also: set all responses for one or more objects to list of objects, only one object to single object.

Note: This PR requires running `npm run generate` to regenerate Prisma client based on new mappings.