### PR TITLE
Adjust amp constraint

### DIFF
--- a/db/migrations/20230911201258_adjust-amp-constraints.js
+++ b/db/migrations/20230911201258_adjust-amp-constraints.js
@@ -1,0 +1,13 @@
+exports.up = function (knex) {
+  return knex.schema.alterTable("amp", function (table) {
+    table.dropChecks(["amp_msat_amount_check"]);
+    table.check("msat_amount >= 1", [], "amp_msat_amount_check");
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.alterTable("amp", function (table) {
+    table.dropChecks(["amp_msat_amount_check"]);
+    table.check("msat_amount >= 1000", [], "amp_msat_amount_check");
+  });
+};


### PR DESCRIPTION
Adjusting amp constraint to `1` to account for 1 sat boosts that are split.