### PR TITLE
Update track and episode views

### DIFF
--- a/db/migrations/20231221141931_fix_date_measurements.js
+++ b/db/migrations/20231221141931_fix_date_measurements.js
@@ -1,0 +1,305 @@
+exports.up = function (knex) {
+  return knex.schema
+    .dropViewIfExists("track_info")
+    .createViewOrReplace("track_info", function (view) {
+      view.columns([
+        "id",
+        "title",
+        "artist",
+        "artist_url",
+        "avatar_url",
+        "artwork_url",
+        "msat_total_30_days",
+        "msat_total_7_days",
+        "msat_total_1_days",
+        "album_title",
+        "live_url",
+        "duration",
+        "created_at",
+        "album_id",
+        "artist_id",
+        "order",
+        "is_processing",
+        "msat_total",
+        "published_at",
+        "is_draft",
+      ]);
+      view.as(
+        knex.raw(
+          `select 
+              track.id as id, 
+              track.title as title,
+              artist.name as artist,
+              artist.artist_url as artist_url,
+              artist.artwork_url as avatar_url,
+              album.artwork_url as artwork_url,
+              thirty.msat_total_30_days as msat_total_30_days, 
+              seven.msat_total_7_days as msat_total_7_days,
+              one.msat_total_1_days as msat_total_1_days, 
+              album.title as album_title,
+              track.live_url as live_url,
+              track.duration as duration,
+              track.created_at as created_at,
+              track.album_id as album_id,
+              track.artist_id as artist_id,
+              track.order as order,
+              track.is_processing as is_processing,
+              track.msat_total as msat_total,
+              track.published_at as published_at,
+              album.is_draft as is_draft
+              from public.track
+              full outer join 
+              (select track_id, 
+                      sum(msat_amount) as msat_total_30_days 
+                      from public.amp 
+                      where created_at > date_trunc('day', NOW() - INTERVAL '30 days')
+                      and created_at < date_trunc('day', NOW()) 
+                      group by track_id) thirty 
+              on thirty.track_id = track.id
+              full outer join 
+              (select track_id, 
+                      sum(msat_amount) as msat_total_7_days 
+                      from public.amp 
+                      where created_at > date_trunc('day', NOW() - INTERVAL '7 days') 
+                      and created_at < date_trunc('day', NOW())
+                      group by track_id) seven 
+              on seven.track_id = track.id
+              full outer join 
+              (select track_id, 
+                      sum(msat_amount) as msat_total_1_days 
+                      from public.amp 
+                      where created_at > date_trunc('day', NOW() - INTERVAL '1 days')
+                      and created_at < date_trunc('day', NOW())
+                      group by track_id) one
+              on one.track_id = track.id
+              join public.album on album.id = track.album_id
+              join public.artist on artist.id = track.artist_id
+              where track.deleted = false`
+        )
+      );
+    })
+    .dropViewIfExists("episode_info")
+    .createViewOrReplace("episode_info", function (view) {
+      view.columns([
+        "id",
+        "title",
+        "description",
+        "podcast",
+        "podcastUrl",
+        "artworkUrl",
+        "msatTotal30Days",
+        "msatTotal7Days",
+        "msatTotal1Days",
+        "liveUrl",
+        "duration",
+        "createdAt",
+        "podcastId",
+        "order",
+        "isProcessing",
+        "publishedAt",
+        "isDraft",
+      ]);
+      view.as(
+        knex.raw(
+          `select 
+            episode.id as id, 
+            episode.title as title,
+            episode.description as description,
+            podcast.name as podcast,
+            podcast.podcast_url as podcastUrl,
+            podcast.artwork_url as artworkUrl,
+            thirty.msat_total_30_days as msatTotal30Days, 
+            seven.msat_total_7_days as msatTotal7Days,
+            one.msat_total_1_days as msatTotal1Days, 
+            episode.live_url as liveUrl,
+            episode.duration as duration,
+            episode.created_at as createdAt,
+            episode.podcast_id as podcastId,
+            episode.order as order,
+            episode.is_processing as isProcessing,
+            episode.published_at as publishedAt,
+            podcast.is_draft as isDraft
+            from public.episode
+            full outer join 
+            (select track_id, 
+                    sum(msat_amount) as msat_total_30_days 
+                    from public.amp 
+                    where created_at > date_trunc('day', NOW() - INTERVAL '30 days')
+                    and created_at < date_trunc('day', NOW()) 
+                    group by track_id) thirty 
+            on thirty.track_id = episode.id
+            full outer join 
+            (select track_id, 
+                    sum(msat_amount) as msat_total_7_days 
+                    from public.amp 
+                    where created_at > date_trunc('day', NOW() - INTERVAL '7 days')
+                    and created_at < date_trunc('day', NOW())
+                    group by track_id) seven 
+            on seven.track_id = episode.id
+            full outer join 
+            (select track_id, 
+                    sum(msat_amount) as msat_total_1_days 
+                    from public.amp 
+                    where created_at > date_trunc('day', NOW() - INTERVAL '1 days')
+                    and created_at < date_trunc('day', NOW())
+                    group by track_id) one 
+            on one.track_id = episode.id
+            join public.podcast on podcast.id = episode.podcast_id
+            where episode.deleted = false`
+        )
+      );
+    });
+};
+
+exports.down = function (knex) {
+  return knex.schema
+    .dropViewIfExists("track_info")
+    .createViewOrReplace("track_info", function (view) {
+      view.columns([
+        "id",
+        "title",
+        "artist",
+        "artist_url",
+        "avatar_url",
+        "artwork_url",
+        "msat_total_30_days",
+        "msat_total_7_days",
+        "msat_total_1_days",
+        "album_title",
+        "live_url",
+        "duration",
+        "created_at",
+        "album_id",
+        "artist_id",
+        "order",
+        "is_processing",
+        "msat_total",
+        "published_at",
+        "is_draft",
+      ]);
+      view.as(
+        knex.raw(
+          `select 
+            track.id as id, 
+            track.title as title,
+            artist.name as artist,
+            artist.artist_url as artist_url,
+            artist.artwork_url as avatar_url,
+            album.artwork_url as artwork_url,
+            thirty.msat_total_30_days as msat_total_30_days, 
+            seven.msat_total_7_days as msat_total_7_days,
+            one.msat_total_1_days as msat_total_1_days, 
+            album.title as album_title,
+            track.live_url as live_url,
+            track.duration as duration,
+            track.created_at as created_at,
+            track.album_id as album_id,
+            track.artist_id as artist_id,
+            track.order as order,
+            track.is_processing as is_processing,
+            track.msat_total as msat_total,
+            track.published_at as published_at,
+            album.is_draft as is_draft
+            from public.track
+            full outer join 
+            (select track_id, 
+                    sum(msat_amount) as msat_total_30_days 
+                    from public.amp 
+                    where created_at > NOW() - INTERVAL '30 days'
+                    and created_at < date_trunc('day', NOW()) 
+                    group by track_id) thirty 
+            on thirty.track_id = track.id
+            full outer join 
+            (select track_id, 
+                    sum(msat_amount) as msat_total_7_days 
+                    from public.amp 
+                    where created_at > NOW() - INTERVAL '7 days' 
+                    and created_at < date_trunc('day', NOW())
+                    group by track_id) seven 
+            on seven.track_id = track.id
+            full outer join 
+            (select track_id, 
+                    sum(msat_amount) as msat_total_1_days 
+                    from public.amp 
+                    where created_at > NOW() - INTERVAL '1 days'
+                    and created_at < date_trunc('day', NOW())
+                    group by track_id) one
+            on one.track_id = track.id
+            join public.album on album.id = track.album_id
+            join public.artist on artist.id = track.artist_id
+            where track.deleted = false`
+        )
+      );
+    })
+    .dropViewIfExists("episode_info")
+    .createViewOrReplace("episode_info", function (view) {
+      view.columns([
+        "id",
+        "title",
+        "description",
+        "podcast",
+        "podcastUrl",
+        "artworkUrl",
+        "msatTotal30Days",
+        "msatTotal7Days",
+        "msatTotal1Days",
+        "liveUrl",
+        "duration",
+        "createdAt",
+        "podcastId",
+        "order",
+        "isProcessing",
+        "publishedAt",
+        "isDraft",
+      ]);
+      view.as(
+        knex.raw(
+          `select 
+          episode.id as id, 
+          episode.title as title,
+          episode.description as description,
+          podcast.name as podcast,
+          podcast.podcast_url as podcastUrl,
+          podcast.artwork_url as artworkUrl,
+          thirty.msat_total_30_days as msatTotal30Days, 
+          seven.msat_total_7_days as msatTotal7Days,
+          one.msat_total_1_days as msatTotal1Days, 
+          episode.live_url as liveUrl,
+          episode.duration as duration,
+          episode.created_at as createdAt,
+          episode.podcast_id as podcastId,
+          episode.order as order,
+          episode.is_processing as isProcessing,
+          episode.published_at as publishedAt,
+          podcast.is_draft as isDraft
+          from public.episode
+          full outer join 
+          (select track_id, 
+                  sum(msat_amount) as msat_total_30_days 
+                  from public.amp 
+                  where created_at > NOW() - INTERVAL '30 days'
+                  and created_at < date_trunc('day', NOW()) 
+                  group by track_id) thirty 
+          on thirty.track_id = episode.id
+          full outer join 
+          (select track_id, 
+                  sum(msat_amount) as msat_total_7_days 
+                  from public.amp 
+                  where created_at > NOW() - INTERVAL '7 days' 
+                  and created_at < date_trunc('day', NOW())
+                  group by track_id) seven 
+          on seven.track_id = episode.id
+          full outer join 
+          (select track_id, 
+                  sum(msat_amount) as msat_total_1_days 
+                  from public.amp 
+                  where created_at > NOW() - INTERVAL '1 days'
+                  and created_at < date_trunc('day', NOW())
+                  group by track_id) one 
+          on one.track_id = episode.id
+          join public.podcast on podcast.id = episode.podcast_id
+          where episode.deleted = false`
+        )
+      );
+    });
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -557,7 +557,7 @@ view TrackInfo {
   isProcessing    Boolean?  @map("is_processing")
   msatTotal       BigInt?   @map("msat_total")
   publishedAt     DateTime? @map("published_at") @db.Timestamptz(6)
-  isDraft         Boolean?  @map("is_draft") 
+  isDraft         Boolean?  @map("is_draft")
 
   @@map("track_info")
 }

--- a/prisma/views/public/EpisodeInfo.sql
+++ b/prisma/views/public/EpisodeInfo.sql
@@ -30,7 +30,9 @@ FROM
               amp
             WHERE
               (
-                (amp.created_at > (NOW() - '30 days' :: INTERVAL))
+                (
+                  amp.created_at > date_trunc('day' :: text, (NOW() - '30 days' :: INTERVAL))
+                )
                 AND (amp.created_at < date_trunc('day' :: text, NOW()))
               )
             GROUP BY
@@ -45,7 +47,9 @@ FROM
             amp
           WHERE
             (
-              (amp.created_at > (NOW() - '7 days' :: INTERVAL))
+              (
+                amp.created_at > date_trunc('day' :: text, (NOW() - '7 days' :: INTERVAL))
+              )
               AND (amp.created_at < date_trunc('day' :: text, NOW()))
             )
           GROUP BY
@@ -60,7 +64,9 @@ FROM
           amp
         WHERE
           (
-            (amp.created_at > (NOW() - '1 day' :: INTERVAL))
+            (
+              amp.created_at > date_trunc('day' :: text, (NOW() - '1 day' :: INTERVAL))
+            )
             AND (amp.created_at < date_trunc('day' :: text, NOW()))
           )
         GROUP BY

--- a/prisma/views/public/TrackInfo.sql
+++ b/prisma/views/public/TrackInfo.sql
@@ -34,7 +34,9 @@ FROM
                 amp
               WHERE
                 (
-                  (amp.created_at > (NOW() - '30 days' :: INTERVAL))
+                  (
+                    amp.created_at > date_trunc('day' :: text, (NOW() - '30 days' :: INTERVAL))
+                  )
                   AND (amp.created_at < date_trunc('day' :: text, NOW()))
                 )
               GROUP BY
@@ -49,7 +51,9 @@ FROM
               amp
             WHERE
               (
-                (amp.created_at > (NOW() - '7 days' :: INTERVAL))
+                (
+                  amp.created_at > date_trunc('day' :: text, (NOW() - '7 days' :: INTERVAL))
+                )
                 AND (amp.created_at < date_trunc('day' :: text, NOW()))
               )
             GROUP BY
@@ -64,7 +68,9 @@ FROM
             amp
           WHERE
             (
-              (amp.created_at > (NOW() - '1 day' :: INTERVAL))
+              (
+                amp.created_at > date_trunc('day' :: text, (NOW() - '1 day' :: INTERVAL))
+              )
               AND (amp.created_at < date_trunc('day' :: text, NOW()))
             )
           GROUP BY


### PR DESCRIPTION
Fixing how we round-off dates when calculating the `msat_sum` columns. New approach rounds the date for the `>` part of the conditional in the same way as the `<` part. For example, instead of 
`created_at > NOW() - INTERVAL '7 days'` which includes the time part of the day, we update to 
`created_at > date_trunc('day', NOW() - INTERVAL '7 days')` to set the time for the day defined to 0.