### PR TITLE
Don't return user owned playlists for user library

### DIFF
--- a/controllers/library.ts
+++ b/controllers/library.ts
@@ -113,26 +113,13 @@ const get_user_library = ({
             .where("library.user_id", "=", pubkey)
         : [];
 
-      // TODO - migrate user owned playlists auto-added to the library onCreate?
-      const userOwnedPlaylists = playlists
-        ? await prisma.playlist.findMany({
-            where: {
-              userId: pubkey,
-            },
-          })
-        : [];
-
-      const sortedPlaylists = [...libraryPlaylists, ...userOwnedPlaylists].sort(
-        (a, b) => b.createdAt - a.createdAt
-      );
-
       res.json({
         success: true,
         data: {
           ...(artists ? { artists: libraryArtists } : {}),
           ...(albums ? { albums: libraryAlbums } : {}),
           ...(tracks ? { tracks: libraryTracks } : {}),
-          ...(playlists ? { playlists: sortedPlaylists } : {}),
+          ...(playlists ? { playlists: libraryPlaylists } : {}),
         },
       });
     } catch (err) {


### PR DESCRIPTION
Instead, we only return favorited playlists, so that we can keep user owned playlists separate