### PR TITLE
Hotfix: Filter by withdraws

### DIFF
--- a/library/payments.ts
+++ b/library/payments.ts
@@ -11,6 +11,7 @@ async function checkUserHasPendingTx(userId: string): Promise<boolean> {
     .knex("transaction")
     .select("transaction.id as id", "transaction.is_pending as isPending")
     .where("transaction.user_id", "=", userId)
+    .andWhere("transaction.withdraw", "=", true) // Only check withdraws
     .andWhere("transaction.is_pending", "=", true)
     .then((data) => {
       if (data.length > 0) {


### PR DESCRIPTION
Resolves an issue where a listener may have zaps to their wallet that are pending, making it unable for the listener to send zaps until the pending invoice settles or expires.