### PR TITLE
Hotfix: Fix missing track info on playlist

### DIFF
--- a/library/playlist.ts
+++ b/library/playlist.ts
@@ -30,10 +30,12 @@ export const getPlaylistTracks = async (playlistId: string): Promise<any[]> => {
 
   // Add OP3 URL prefix to artwork URLs
   tracks.forEach((track) => {
-    track.trackInfo.liveUrl = addOP3URLPrefix({
-      url: track.trackInfo.liveUrl,
-      albumId: track.trackInfo.albumId,
-    });
+    if (track.trackInfo) {
+      track.trackInfo.liveUrl = addOP3URLPrefix({
+        url: track.trackInfo.liveUrl,
+        albumId: track.trackInfo.albumId,
+      });
+    }
   });
 
   // Destructure the trackInfo object with orderInt

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -178,7 +178,7 @@ model PlaylistTrack {
   createdAt  DateTime? @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt  DateTime? @default(now()) @map("updated_at") @db.Timestamptz(6)
   orderInt   Int?      @default(0) @map("order_int")
-  trackInfo  TrackInfo @relation(fields: [trackId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "playlist_track_track_id_foreign")
+  trackInfo  TrackInfo? @relation(fields: [trackId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "playlist_track_track_id_foreign")
 
   @@index([playlistId], map: "idx_playlist_track_playlist_id")
   @@map("playlist_track")


### PR DESCRIPTION
Fix for issue that breaks get playlist if a track is not returning from the trackInfo view.

Error: `Inconsistent query result: Field trackInfo is required to return data, got `null` instead.`

https://wavlake.sentry.io/issues/5932775775