### PR TITLE
Add delay

### DIFF
--- a/library/withdraw.ts
+++ b/library/withdraw.ts
@@ -73,6 +73,9 @@ export const handleCompletedForward = async ({
 };
 
 async function checkWithdrawalStatus(transactionId: number) {
+  // Add delay to prevent checking status before it is intially updated
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+
   return db
     .knex("transaction")
     .select("is_pending")


### PR DESCRIPTION
Issue: Callback can fire immediately and function will return pending status as `true` even if withdrawal has gone through.

Simple fix is to put a delay in this function, which is only called on the callback route.