### PR TITLE
Hotfix: move track_info query to library function

### DIFF
--- a/controllers/meta.ts
+++ b/controllers/meta.ts
@@ -137,16 +137,6 @@ const get_content_type = asyncHandler(async (req, res, next) => {
       .send({ success: false, message: "Content not found" });
   }
 
-  // getContentFromId doesnt return artwork_url for tracks
-  if (contentType === "track") {
-    const artworkUrl = await db
-      .knex("album")
-      .select("artwork_url")
-      .where("id", contentData.album_id)
-      .first();
-    contentData.artwork_url = artworkUrl?.artwork_url;
-  }
-
   return res.status(200).send({
     success: true,
     data: {

--- a/library/content.ts
+++ b/library/content.ts
@@ -152,12 +152,19 @@ export const getContentFromId = async (contentId) => {
   }
 
   // return all data for the content
-  const content = await db
-    .knex(contentType)
-    .select("*")
-    .where("id", "=", contentId)
-    .andWhere("deleted", "=", false)
-    .first();
+  const content =
+    contentType === "track"
+      ? await db
+          .knex("track_info")
+          .select("*")
+          .where("id", "=", contentId)
+          .first()
+      : await db
+          .knex(contentType)
+          .select("*")
+          .where("id", "=", contentId)
+          .andWhere("deleted", "=", false)
+          .first();
 
   return content;
 };


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Move the `track_info` query and logic for getting `artwork_url` from the `get_content_type` controller function to the `getContentFromId` library function to centralize querying logic.

### Why are these changes being made?

Centralizing `track_info` querying logic improves code maintainability and reusability, ensuring that track-related data, such as `artwork_url`, is consistently handled in one place. This helps avoid duplication and potential errors in querying across different parts of the codebase. The change provides a cleaner separation of concerns by keeping the controller focused on handling HTTP requests and responses.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->