### PR TITLE
add zap event to single tx route

### DIFF
--- a/library/queries/transactions.ts
+++ b/library/queries/transactions.ts
@@ -39,6 +39,11 @@ export function getTopUpDetail(userId, paymentId) {
 export function getZapDetail(userId, paymentId) {
   return db
     .knex("transaction")
+    .leftJoin(
+      "zap_request",
+      "zap_request.payment_hash",
+      db.knex.raw(`CONCAT('transaction-', CAST("transaction"."id" as text))`)
+    )
     .select(
       "transaction.fee_msat as feemsat",
       "transaction.success as success",
@@ -49,7 +54,8 @@ export function getZapDetail(userId, paymentId) {
       "transaction.id as id",
       "transaction.msat_amount as msatAmount",
       "transaction.failure_reason as failureReason",
-      "transaction.created_at as createDate"
+      "transaction.created_at as createDate",
+      "zap_request.event as zapEvent"
     )
     .where("transaction.id", "=", paymentId)
     .andWhere("transaction.user_id", "=", userId)


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add `zap_event` field retrieval by left joining the `zap_request` table in the `getZapDetail` function within the transactions queries.

### Why are these changes being made?

This change enables retrieval of the `zap_event` from the `zap_request` table for transactions, enhancing the detail and context available for each transaction request. By joining the tables using a specific `payment_hash` format, comprehensive transactions data, including any related zap events, is accessed efficiently.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->